### PR TITLE
fix: ldap error swallowed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -70,9 +70,7 @@ func (c *Conn) Bind(upn, password string) (bool, error) {
 	err := c.Conn.Bind(upn, password)
 	if err != nil {
 		if e, ok := err.(*ldap.Error); ok {
-			if e.ResultCode == ldap.LDAPResultInvalidCredentials {
-				return false, nil
-			}
+			return false, e
 		}
 		return false, fmt.Errorf("Bind error (%s): %v", upn, err)
 	}


### PR DESCRIPTION
This fix will return the origin LDAP error which is fully formated at  [go-ldap](https://github.com/go-ldap/ldap/blob/master/error.go#L192).  